### PR TITLE
Add macromate.yaml

### DIFF
--- a/macromate.yaml
+++ b/macromate.yaml
@@ -1,0 +1,64 @@
+name: "Materia Raiding"
+macros:
+  # =============
+  # = Criterion =
+  # =============
+
+  - name: AAI - Boss 1
+    group: "Criterion/AAI"
+    iconId: 65105
+    markdownUrl: _criterion/aai.md
+    markdownMacroCodeBlockIndex: 0
+
+  - name: AAI - Boss 2
+    group: "Criterion/AAI"
+    iconId: 65105
+    markdownUrl: _criterion/aai.md
+    markdownMacroCodeBlockIndex: 1
+
+  - name: AAI - Boss 3
+    group: "Criterion/AAI"
+    iconId: 65105
+    markdownUrl: _criterion/aai.md
+    markdownMacroCodeBlockIndex: 2
+
+  # ============
+  # = Extremes =
+  # ============
+
+  - name: EX1
+    group: "Extreme"
+    iconId: 81825
+    markdownUrl: _extreme/ex1.md
+
+  - name: EX2
+    group: "Extreme"
+    iconId: 81807
+    markdownUrl: _extreme/ex2.md
+
+  # ==========
+  # = Savage =
+  # ==========
+
+  - name: M1S
+    group: "Savage"
+    iconId: 26457
+    markdownUrl: _savage/m1s.md
+    notes: |
+      Changelog:
+      - Jul 23, 2024: Introduced
+
+  - name: M2S
+    group: "Savage"
+    iconId: 26458
+    markdownUrl: _savage/m2s.md
+
+  - name: M3S
+    group: "Savage"
+    iconId: 26459
+    markdownUrl: _savage/m3s.md
+
+  - name: M4S
+    group: "Savage"
+    iconId: 26460
+    markdownUrl: _savage/m4s.md


### PR DESCRIPTION
# Why

We want to make it easy for materia raiders to easily get macro updates for raiding content, especially early in a patch when the macros are updating daily.

[Macro Mate](https://github.com/grittyfrog/MacroMate) added a new feature in version `1.0.19.0` called "Subscriptions" these let you subscribe to a third party repository to receive macros and macro updates. 

With this yaml file, people can subscribe to Materia Raiding to get all of the raiding macros. When an update is made to the yaml or the referenced markdown code blocks Macro Mate will tell people that an update is available.

I also added a `notes` field to `M1S` to show what change-log functionality looks like.

If you want to try this for yourself before merging you can:

1. Install `Macro Mate` in FFXIV using Dalamud
2. Click `New > Subscription
3. Set Subscription URL to `https://raw.githubusercontent.com/grittyfrog/materiaraiding/main/macromate.yaml`
4. Click `Save`

You'll see a new group in Macro Mate with all the materia macros, when they are updated the group will notify you of the update and prompt you to sync. Updates are checked on login and every 2 hours (configurable).

See also [Macro Mate - docs/subscriptions.md](https://github.com/grittyfrog/MacroMate/blob/master/docs/subscriptions.md) for more details about subscriptions.

# Imports

Defines imports for:

- Criterion/AAI
- EX1 / EX2
- M1S / M2S / M3S / M4S

Skipped imports for

- Criterion/AMR: These aren't in separate markdown blocks, would be an easy addition
- Criterion/ASS: These aren't in separate markdown blocks, would be an easy addition
- Ultimates: Wasn't clear which macros should be included